### PR TITLE
Remove font size styling from .pf-font-size class

### DIFF
--- a/akwad_frappe_fixes/setup.py
+++ b/akwad_frappe_fixes/setup.py
@@ -223,10 +223,6 @@ def insert_print_style():
                 font-family: "Rubik", sans-serif;
             }
 
-            .pf-font-size {
-                font-size: 14px;
-            }
-
             .pf-heading {
                 margin: 10px 0;
                 width: 100%;


### PR DESCRIPTION
Removed font size styling for .pf-font-size class because it overrides the option in the Print Settings.