### PR TITLE
 Add QR Code Method and Template

### DIFF
--- a/akwad_frappe_fixes/hooks.py
+++ b/akwad_frappe_fixes/hooks.py
@@ -70,7 +70,8 @@ app_include_js = ["/assets/akwad_frappe_fixes/js/collapse_sidebar.js" , "/assets
 
 jinja = {
   "methods": [
-    "akwad_frappe_fixes.print_format_utils.workflow_signatures.get_workflow_signatures_for_print"
+    "akwad_frappe_fixes.print_format_utils.workflow_signatures.get_workflow_signatures_for_print",
+    "akwad_frappe_fixes.print_format_utils.qr_code.get_qr_print_link",
   ]
 }
 

--- a/akwad_frappe_fixes/print_format_utils/qr_code.py
+++ b/akwad_frappe_fixes/print_format_utils/qr_code.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.utils import get_url
+
+def get_qr_print_link(doctype, name, print_format=None):
+    key = frappe.get_doc(doctype, name).get_document_share_key()
+    return frappe.get_template("akwad_frappe_fixes/templates/qr_code.html").render(
+        {
+            "url": get_url(),
+            "doctype": doctype,
+            "name": name,
+            "print_format": print_format,
+            "key": key,
+        }
+    )

--- a/akwad_frappe_fixes/templates/qr_code.html
+++ b/akwad_frappe_fixes/templates/qr_code.html
@@ -1,0 +1,11 @@
+{% set print_url = url
+    + "/printview?doctype=" + doctype|urlencode
+    + "&name=" + name|urlencode
+    + "&format=" + print_format|urlencode
+    + "&no_letterhead=0"
+    + "&key=" + key
+%}
+
+<a href="{{ print_url }}" target="_blank">
+    <img src="https://api.qrserver.com/v1/create-qr-code/?data={{ print_url|urlencode }}&size=120x120">
+</a>


### PR DESCRIPTION
Implements a new method (`get_qr_print_link`) and its associated template (`qr_code.html`) to display a scannable QR code on print formats.